### PR TITLE
Adjusted positions of UI components

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -36,11 +36,18 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                     <Stack height={"100vh"} minHeight={0} id="app-wrapper">
                       <Header maintenance={false} />
                       {/* Overflow=auto provides scrolling ancestor for OpenElementsTab. This allows it to be position=sticky with top=0, and right under AppBar*/}
-                      <Stack flexGrow={1} overflow={"auto"} minHeight={0} id="content-wrapper">
+                      <Stack
+                        flexGrow={1}
+                        overflow={"auto"}
+                        height={"100vh"}
+                        minHeight={0}
+                        sx={{ marginRight: 1 }}
+                        id="content-wrapper"
+                      >
                         <Stack flexGrow={1}>{children}</Stack>
-                        <Footer />
                       </Stack>
                     </Stack>
+                    <Footer />
                   </OpenEntitiesContextProvider>
                 </MenuControlProvider>
               </ThemeProvider>

--- a/src/common/components/EntityDetails/EntityDetailsLayout.tsx
+++ b/src/common/components/EntityDetails/EntityDetailsLayout.tsx
@@ -25,7 +25,7 @@ export default function EntityDetailsLayout({ assembly, entityID, entityType, ch
       <Stack direction={"row"} id="element-details-wrapper" height={"100%"}>
         {/* View tabs, shown only on desktop */}
         <Box sx={{ display: { xs: "none", md: "initial", height: "100%" } }} id="element-details-desktop-tabs">
-          <Box sx={{ position: "fixed", height: "100%" }}>
+          <Box sx={{ position: "absolute", height: "100%" }}>
             <EntityDetailsTabs
               assembly={assembly}
               entityType={entityType}

--- a/src/common/components/EntityDetails/OpenEntitiesTabs/OpenEntitiesTabBar.tsx
+++ b/src/common/components/EntityDetails/OpenEntitiesTabs/OpenEntitiesTabBar.tsx
@@ -229,7 +229,7 @@ export const OpenEntityTabs = ({ children }: { children?: React.ReactNode }) => 
   return (
     <TabContext value={tabIndex}>
       {/* z index of scrollbar in DataGrid is 60 */}
-      <Paper elevation={1} square sx={{ position: "sticky", top: 0, zIndex: 61 }} id="open-elements-tabs">
+      <Paper elevation={1} square sx={{ position: "sticky", top: 0, zIndex: 1 }} id="open-elements-tabs">
         <Stack direction={"row"}>
           <DragDropContext onDragEnd={onDragEnd}>
             <OpenTabs {...openTabsProps} />

--- a/src/common/components/Footer.tsx
+++ b/src/common/components/Footer.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { Typography, Box, Grid, Link as MuiLink, Stack } from "@mui/material";
+import { Typography, Box, Grid, Link as MuiLink, Stack, useTheme } from "@mui/material";
 import Image from "next/image";
 import { LinkComponent } from "./LinkComponent";
 
@@ -52,6 +52,7 @@ export default function Footer() {
         zIndex: (theme) => theme.zIndex.appBar,
         color: "#fff",
         paddingX: 6,
+        position: "absolute",
       }}
     >
       <Grid container spacing={6} my={3}>

--- a/src/common/components/Header/Header.tsx
+++ b/src/common/components/Header/Header.tsx
@@ -138,7 +138,7 @@ function Header({ maintenance }: ResponsiveAppBarProps) {
   };
 
   return (
-    <Box position={"sticky"} top={0} zIndex={1}>
+    <Box position={"sticky"} top={0} zIndex={10}>
       <Stack
         direction={"row"}
         style={{


### PR DESCRIPTION
In layout.tsx
- increased right margin of content wrapper to 1 (for better scroll bar position)
- put the footer below the content stack

in EntityDetailsLayout.tsx
- changed desktop tabs to absolute position

In OpenEntitiesTabBar
- set z index to 1 to ensure it goes below the appbar

In Footer.tsx
- set position to absolute

In Header.tsx
- increased z index to 10