### PR TITLE
Fix geneMap in useGeneData

### DIFF
--- a/src/common/hooks/useGeneData.ts
+++ b/src/common/hooks/useGeneData.ts
@@ -103,12 +103,12 @@ export const useGeneData = <T extends UseGeneDataParams>({
 
       // Add v29 genes first
       v29Query.data?.gene?.forEach((gene) => {
-        if (gene) geneMap.set(gene.id, gene);
+        if (gene) geneMap.set(gene.id.split(".")[0], gene);
       });
 
       // Override with v40 genes
       v40Query.data?.gene?.forEach((gene) => {
-        if (gene) geneMap.set(gene.id, gene);
+        if (gene) geneMap.set(gene.id.split(".")[0], gene);
       });
 
       // Convert back to array


### PR DESCRIPTION
Excludes the version number in the gene ID when attempting to overwrite existing entries in the geneMap. 

Example: SOX4 has ID ENSG00000124766.7 in v40, and ENSG00000124766.6 in v29. When adding the entries into the map based on the IDs, they were treated as unique entries.

By extension, fixes the highlight alignment issue in the GB
<img width="1169" height="204" alt="image" src="https://github.com/user-attachments/assets/741aea5d-e923-4a38-aa15-7e0b432b696f" />
