### PR TITLE
Attach api key in header + ui-components v3.0.0

### DIFF
--- a/codegen.ts
+++ b/codegen.ts
@@ -2,8 +2,7 @@ import { CodegenConfig } from "@graphql-codegen/cli";
 import Config from "./src/common/config.json";
 
 const config: CodegenConfig = {
-  schema: [{ [Config.API.CcreAPI]: { headers: { "api-key": process.env.SCREEN_API_KEY! } }, [Config.API.MOHD_API]: {headers: { "api-key": process.env.MOHD_API_KEY! }} }],
-  //schema: [Config.API.CcreAPI, Config.API.MOHD_API],
+  schema: [{ [Config.API.CcreAPI]: { headers: { "api-key": process.env.SCREEN_API_KEY! } } }],
   documents: ["src/**/*.{ts,tsx}"],
   generates: {
     "./src/common/types/generated/": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@visx/visx": "^3",
     "@weng-lab/genomebrowser": "1.8.5-beta.0",
     "@weng-lab/genomebrowser-ui": "0.3.6",
-    "@weng-lab/ui-components": "3.0.0-beta.0",
+    "@weng-lab/ui-components": "3.0.0",
     "@weng-lab/visualization": "1.3.2",
     "bpnet-ui": "^0.3.8",
     "d3-scale-chromatic": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "d3-scale-chromatic": "^3.1.0",
     "html2canvas": "^1.4.1",
     "logo-test": "^0.0.5",
-    "dotenv-cli": "^11.0.0",
     "lz-string": "^1.5.0",
     "next": "^15",
     "queryz": "^0.0.3",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "d3-scale-chromatic": "^3.1.0",
     "html2canvas": "^1.4.1",
     "logo-test": "^0.0.5",
+    "dotenv-cli": "^11.0.0",
     "lz-string": "^1.5.0",
     "next": "^15",
     "queryz": "^0.0.3",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@visx/visx": "^3",
     "@weng-lab/genomebrowser": "1.8.5-beta.0",
     "@weng-lab/genomebrowser-ui": "0.3.6",
-    "@weng-lab/ui-components": "file:/Users/jonathanfisher/Documents/GitHub/web-components/packages/ui-components",
+    "@weng-lab/ui-components": "3.0.0-beta.0",
     "@weng-lab/visualization": "1.3.2",
     "bpnet-ui": "^0.3.8",
     "d3-scale-chromatic": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@visx/visx": "^3",
     "@weng-lab/genomebrowser": "1.8.5-beta.0",
     "@weng-lab/genomebrowser-ui": "0.3.6",
-    "@weng-lab/ui-components": "2.2.3",
+    "@weng-lab/ui-components": "file:/Users/jonathanfisher/Documents/GitHub/web-components/packages/ui-components",
     "@weng-lab/visualization": "1.3.2",
     "bpnet-ui": "^0.3.8",
     "d3-scale-chromatic": "^3.1.0",

--- a/src/app/[assembly]/[entityType]/[entityID]/[[...tab]]/_CcreTabs/_Genes/CcreLinkedGenes.tsx
+++ b/src/app/[assembly]/[entityType]/[entityID]/[[...tab]]/_CcreTabs/_Genes/CcreLinkedGenes.tsx
@@ -80,33 +80,14 @@ export default function CcreLinkedGenes({ entity }: EntityViewComponentProps) {
     method,
   });
 
-  //Not really sure how this works, but only way to anchor the popper since the extra toolbarSlot either gets unrendered or unmouted after
-  //setting the anchorEl to the button
-  const [virtualAnchor, setVirtualAnchor] = useState<{
-    getBoundingClientRect: () => DOMRect;
-  } | null>(null);
+  const [open, setOpen] = useState(false);
 
   const handleClickClose = () => {
-    if (virtualAnchor) {
-      setVirtualAnchor(null);
-    }
+    setOpen(false);
   };
 
   const handleMethodSelected = (method: string) => {
     setMethod(method);
-  };
-
-  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
-    if (virtualAnchor) {
-      // If already open, close it
-      setVirtualAnchor(null);
-    } else {
-      // Open it, store the current position
-      const rect = event.currentTarget.getBoundingClientRect();
-      setVirtualAnchor({
-        getBoundingClientRect: () => rect,
-      });
-    }
   };
 
   // make types for the data
@@ -200,19 +181,23 @@ export default function CcreLinkedGenes({ entity }: EntityViewComponentProps) {
             )}
           </Stack>
           <Tooltip title="Advanced Filters">
-            <Button variant="outlined" onClick={handleClick}>
+            <Button variant="outlined" onClick={() => setOpen(true)}>
               Change Method
             </Button>
           </Tooltip>
         </Stack>
       ),
-      toolbarSlot: (
-        <Tooltip title="Advanced Filters">
-          <Button variant="outlined" onClick={handleClick}>
-            Change Method
-          </Button>
-        </Tooltip>
-      ),
+      slotProps: {
+        toolbar: {
+          extra: (
+            <Tooltip title="Advanced Filters">
+              <Button variant="outlined" onClick={() => setOpen(true)}>
+                Change Method
+              </Button>
+            </Tooltip>
+          ),
+        },
+      },
     },
   ];
 
@@ -257,7 +242,7 @@ export default function CcreLinkedGenes({ entity }: EntityViewComponentProps) {
       >
         <SelectCompuGenesMethod
           method={method}
-          open={Boolean(virtualAnchor)}
+          open={open}
           setOpen={handleClickClose}
           onMethodSelect={handleMethodSelected}
         />

--- a/src/app/[assembly]/[entityType]/[entityID]/[[...tab]]/_CcreTabs/_cCRE/BiosampleActivity.tsx
+++ b/src/app/[assembly]/[entityType]/[entityID]/[[...tab]]/_CcreTabs/_cCRE/BiosampleActivity.tsx
@@ -488,7 +488,9 @@ export const BiosampleActivity = ({ entity }: EntityViewComponentProps) => {
     ? [{ ...data_Ct_Agnostic.cCREQuery[0], displayname: "Cell Type Agnostic" }]
     : undefined;
 
-  const disableCsvEscapeChar = { slotProps: { toolbar: { csvOptions: { escapeFormulas: false } } } };
+  const disableCsvEscapeChar = {
+    toolbar: { csvOptions: { escapeFormulas: false }, excelOptions: { escapeFormulas: false } },
+  };
 
   const partialCollectionChromAccess = useMemo(() => {
     if (!partialDataCollection) return;
@@ -547,7 +549,7 @@ export const BiosampleActivity = ({ entity }: EntityViewComponentProps) => {
             autoHeight
             hideFooter
             showToolbar={false}
-            {...disableCsvEscapeChar}
+            slotProps={disableCsvEscapeChar}
           />
           <div>
             <ProportionsBar
@@ -561,14 +563,18 @@ export const BiosampleActivity = ({ entity }: EntityViewComponentProps) => {
             />
             <Table
               label="Core Collection"
-              labelTooltip={CORE_COLLECTION_TOOLTIP}
               rows={coreCollection}
               columns={coreAndPartialCols}
               loading={loadingCorePartialAncillary}
               error={errorCorePartialAncillary}
               divHeight={{ height: "400px" }}
               initialState={{ sorting: { sortModel: [{ field: "dnase", sort: "desc" }] } }}
-              {...disableCsvEscapeChar}
+              slotProps={{
+                toolbar: {
+                  labelTooltip: CORE_COLLECTION_TOOLTIP,
+                  ...disableCsvEscapeChar.toolbar,
+                },
+              }}
             />
           </div>
           <div>
@@ -587,26 +593,34 @@ export const BiosampleActivity = ({ entity }: EntityViewComponentProps) => {
             />
             <Table
               label="Partial Data Collection"
-              labelTooltip={PARTIAL_COLLECTION_TOOLTIP}
               rows={partialDataCollection}
               columns={coreAndPartialCols}
               loading={loadingCorePartialAncillary}
               error={errorCorePartialAncillary}
               divHeight={{ height: "400px" }}
               initialState={{ sorting: { sortModel: [{ field: "dnase", sort: "desc" }] } }}
-              {...disableCsvEscapeChar}
+              slotProps={{
+                toolbar: {
+                  labelTooltip: PARTIAL_COLLECTION_TOOLTIP,
+                  ...disableCsvEscapeChar.toolbar,
+                },
+              }}
             />
           </div>
           <Table
             label="Ancillary Collection"
-            labelTooltip={ANCILLARY_COLLECTION_TOOLTIP}
             rows={ancillaryCollection}
             columns={ancillaryCols}
             loading={loadingCorePartialAncillary}
             error={errorCorePartialAncillary}
             divHeight={{ height: "400px" }}
             initialState={{ sorting: { sortModel: [{ field: "atac", sort: "desc" }] } }}
-            {...disableCsvEscapeChar}
+            slotProps={{
+              toolbar: {
+                labelTooltip: ANCILLARY_COLLECTION_TOOLTIP,
+                ...disableCsvEscapeChar.toolbar,
+              },
+            }}
           />
         </Stack>
       ) : tab === "add_classification" ? (

--- a/src/app/[assembly]/[entityType]/[entityID]/[[...tab]]/_GeneTabs/_Gene/CalcNearbyCCREs.tsx
+++ b/src/app/[assembly]/[entityType]/[entityID]/[[...tab]]/_GeneTabs/_Gene/CalcNearbyCCREs.tsx
@@ -16,7 +16,7 @@ import { Assembly } from "common/types/globalTypes";
 
 interface CalculateNearbyCCREsPopperProps {
   open: boolean;
-  anchorEl: any; // virtual anchor object
+  anchorEl: HTMLButtonElement | null;
   handleClickAway: () => void;
   geneName: string;
   calcMethod: "body" | "tss" | "3gene";

--- a/src/app/[assembly]/[entityType]/[entityID]/[[...tab]]/_GeneTabs/_Transcript/TranscriptExpressionTable.tsx
+++ b/src/app/[assembly]/[entityType]/[entityID]/[[...tab]]/_GeneTabs/_Transcript/TranscriptExpressionTable.tsx
@@ -115,7 +115,12 @@ const TranscriptExpressionTable = ({
       label={TableLabel}
       rows={rows}
       loading={loading}
-      downloadFileName={"TSS Expression at " + selectedPeak}
+      slotProps={{
+        toolbar: {
+          csvOptions: { fileName: "TSS Expression at " + selectedPeak },
+          excelOptions: { fileName: "TSS Expression at " + selectedPeak },
+        },
+      }}
     />
   );
 };

--- a/src/app/[assembly]/[entityType]/[entityID]/[[...tab]]/_GeneTabs/_cCREs/ComputationalLinkedCcres.tsx
+++ b/src/app/[assembly]/[entityType]/[entityID]/[[...tab]]/_GeneTabs/_cCREs/ComputationalLinkedCcres.tsx
@@ -39,33 +39,14 @@ export default function ComputationalLinkedCcres({
     method,
   });
 
-  //Not really sure how this works, but only way to anchor the popper since the extra toolbarSlot either gets unrendered or unmouted after
-  //setting the anchorEl to the button
-  const [virtualAnchor, setVirtualAnchor] = useState<{
-    getBoundingClientRect: () => DOMRect;
-  } | null>(null);
+  const [open, setOpen] = useState(false);
 
   const handleClickClose = () => {
-    if (virtualAnchor) {
-      setVirtualAnchor(null);
-    }
+    setOpen(false);
   };
 
   const handleMethodSelected = (method: string) => {
     setMethod(method);
-  };
-
-  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
-    if (virtualAnchor) {
-      // If already open, close it
-      setVirtualAnchor(null);
-    } else {
-      // Open it, store the current position
-      const rect = event.currentTarget.getBoundingClientRect();
-      setVirtualAnchor({
-        getBoundingClientRect: () => rect,
-      });
-    }
   };
 
   const CompuLinkedcCREs_columns: TableColDef<(typeof dataCompucCREs)[number]>[] = [
@@ -261,19 +242,23 @@ export default function ComputationalLinkedCcres({
             )}
           </Stack>
           <Tooltip title="Advanced Filters">
-            <Button variant="outlined" onClick={handleClick}>
+            <Button variant="outlined" onClick={() => setOpen(true)}>
               Change Method
             </Button>
           </Tooltip>
         </Stack>
       ),
-      toolbarSlot: (
-        <Tooltip title="Advanced Filters">
-          <Button variant="outlined" onClick={handleClick}>
-            Change Method
-          </Button>
-        </Tooltip>
-      ),
+      slotProps: {
+        toolbar: {
+          extra: (
+            <Tooltip title="Advanced Filters">
+              <Button variant="outlined" onClick={() => setOpen(true)}>
+                Change Method
+              </Button>
+            </Tooltip>
+          ),
+        },
+      },
     },
   ];
 
@@ -287,7 +272,7 @@ export default function ComputationalLinkedCcres({
       >
         <SelectCompuGenesMethod
           method={method}
-          open={Boolean(virtualAnchor)}
+          open={open}
           setOpen={handleClickClose}
           onMethodSelect={handleMethodSelected}
         />

--- a/src/app/[assembly]/[entityType]/[entityID]/[[...tab]]/_GeneTabs/_cCREs/DistanceLinkedCcres.tsx
+++ b/src/app/[assembly]/[entityType]/[entityID]/[[...tab]]/_GeneTabs/_cCREs/DistanceLinkedCcres.tsx
@@ -6,7 +6,7 @@ import { UseGeneDataReturn } from "common/hooks/useGeneData";
 import { LinkComponent } from "common/components/LinkComponent";
 import { Table, TableColDef } from "@weng-lab/ui-components";
 import CalculateIcon from "@mui/icons-material/Calculate";
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useMemo, useState, useRef } from "react";
 import CalculateNearbyCCREsPopper from "../_Gene/CalcNearbyCCREs";
 import { Assembly } from "common/types/globalTypes";
 import { InfoOutlineRounded } from "@mui/icons-material";
@@ -33,6 +33,8 @@ export default function DistanceLinkedCcres({
 }) {
   const [calcMethod, setCalcMethod] = useState<"body" | "tss" | "3gene">("tss");
   const [distance, setDistance] = useState<number>(10000);
+  const [open, setOpen] = useState(false);
+  const buttonRef = useRef<HTMLButtonElement>(null);
 
   const { data: dataNearby, loading: loadingNearby } = useNearbycCREs(
     geneData,
@@ -40,21 +42,6 @@ export default function DistanceLinkedCcres({
     assembly as Assembly,
     distance
   );
-
-  const [virtualAnchor, setVirtualAnchor] = React.useState<{
-    getBoundingClientRect: () => DOMRect;
-  } | null>(null);
-
-  const handleClick = useCallback((event: React.MouseEvent<HTMLButtonElement>) => {
-    if (virtualAnchor) {
-      setVirtualAnchor(null);
-    } else {
-      const rect = event.currentTarget.getBoundingClientRect();
-      setVirtualAnchor({
-        getBoundingClientRect: () => rect,
-      });
-    }
-  }, [virtualAnchor]);
 
   const handleMethodChange = (method: "body" | "tss" | "3gene") => {
     setCalcMethod(method);
@@ -65,9 +52,7 @@ export default function DistanceLinkedCcres({
   };
 
   const handleClickAway = () => {
-    if (virtualAnchor) {
-      setVirtualAnchor(null);
-    }
+    setOpen(false);
   };
 
   const { data: dataCcreDetails, loading: loadingCcreDetails } = useCcreData({
@@ -199,24 +184,34 @@ export default function DistanceLinkedCcres({
           <Typography>No Nearby cCREs Found</Typography>
         </Stack>
         <Tooltip title="Calculate Nearby cCREs by">
-          <Button onClick={handleClick} variant="outlined" endIcon={<CalculateIcon />}>
+          <Button
+            ref={buttonRef}
+            onClick={() => setOpen(true)}
+            variant="outlined"
+            endIcon={<CalculateIcon />}
+          >
             Change Method
           </Button>
         </Tooltip>
       </Stack>
     ),
-    [handleClick]
+    []
   );
 
-  const toolbarSlot = useMemo(
+  const toolbarExtra = useMemo(
     () => (
       <Tooltip title="Calculate Nearby cCREs by">
-        <Button onClick={handleClick} variant="outlined" endIcon={<CalculateIcon />}>
+        <Button
+          ref={buttonRef}
+          onClick={() => setOpen(true)}
+          variant="outlined"
+          endIcon={<CalculateIcon />}
+        >
           Change Method
         </Button>
       </Tooltip>
     ),
-    [handleClick]
+    []
   );
 
   const labelTooltip = useMemo(
@@ -256,12 +251,16 @@ export default function DistanceLinkedCcres({
         }}
         emptyTableFallback={emptyTableFallback}
         divHeight={{ height: assembly === "GRCh38" ? "400px" : "600px" }}
-        toolbarSlot={toolbarSlot}
-        labelTooltip={labelTooltip}
+        slotProps={{
+          toolbar: {
+            extra: toolbarExtra,
+            labelTooltip: labelTooltip,
+          },
+        }}
       />
       <CalculateNearbyCCREsPopper
-        open={Boolean(virtualAnchor)}
-        anchorEl={virtualAnchor}
+        open={open}
+        anchorEl={buttonRef.current}
         handleClickAway={handleClickAway}
         distance={distance}
         geneName={geneData.data?.name}

--- a/src/app/[assembly]/[entityType]/[entityID]/[[...tab]]/_GwasTabs/_BiosampleEnrichment/BiosampleEnrichmentTable.tsx
+++ b/src/app/[assembly]/[entityType]/[entityID]/[[...tab]]/_GwasTabs/_BiosampleEnrichment/BiosampleEnrichmentTable.tsx
@@ -91,7 +91,11 @@ const BiosampleEnrichmentTable = ({ enrichmentdata, tableProps }: BiosampleEnric
       error={!!error}
       label={`Suggested Biosamples`}
       emptyTableFallback={"No Suggested Biosamples found for this study"}
-      labelTooltip={LabelTooltip}
+      slotProps={{
+        toolbar: {
+          labelTooltip: LabelTooltip,
+        },
+      }}
     />
   );
 };

--- a/src/app/[assembly]/[entityType]/[entityID]/[[...tab]]/_GwasTabs/_Ccre/GWASStudyCcres.tsx
+++ b/src/app/[assembly]/[entityType]/[entityID]/[[...tab]]/_GwasTabs/_Ccre/GWASStudyCcres.tsx
@@ -13,29 +13,10 @@ import { BiosampleSelectDialog } from "common/components/BiosampleSelectDialog";
 const GWASStudyCcres = ({ entity }: EntityViewComponentProps) => {
   const { data, loading, error } = useGWASStudyData({ studyid: [entity.entityID] });
 
-  //Not really sure how this works, but only way to anchor the popper since the extra toolbarSlot either gets unrendered or unmouted after
-  //setting the anchorEl to the button
-  const [virtualAnchor, setVirtualAnchor] = useState<{
-    getBoundingClientRect: () => DOMRect;
-  } | null>(null);
-
-  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
-    if (virtualAnchor) {
-      // If already open, close it
-      setVirtualAnchor(null);
-    } else {
-      // Open it, store the current position
-      const rect = event.currentTarget.getBoundingClientRect();
-      setVirtualAnchor({
-        getBoundingClientRect: () => rect,
-      });
-    }
-  };
+  const [open, setOpen] = useState(false);
 
   const handleClickClose = () => {
-    if (virtualAnchor) {
-      setVirtualAnchor(null);
-    }
+    setOpen(false);
   };
   const [selectedBiosample, setSelectedBiosample] = useState<EncodeBiosample>(null);
 
@@ -245,9 +226,11 @@ const GWASStudyCcres = ({ entity }: EntityViewComponentProps) => {
         emptyTableFallback={"Error fetching information about this study"}
         //temp fix to get visual loading state without specifying height once loaded. See https://github.com/weng-lab/web-components/issues/22
         divHeight={!data ? { height: "182px" } : undefined}
-        labelTooltip={
-          "LD Blocks are regions of the genome where genetic variants are inherited together due to high levels of linkage disequilibrium (LD)"
-        }
+        slotProps={{
+          toolbar: {
+            labelTooltip: "LD Blocks are regions of the genome where genetic variants are inherited together due to high levels of linkage disequilibrium (LD)",
+          },
+        }}
         autoHeight
         hideFooter
       />
@@ -285,18 +268,22 @@ const GWASStudyCcres = ({ entity }: EntityViewComponentProps) => {
           },
         }}
         divHeight={{ height: "600px" }}
-        labelTooltip={"cCREs intersected against SNPs identified by selected GWAS study"}
-        toolbarSlot={
-          <Tooltip title="Advanced Filters">
-            <Button variant="outlined" onClick={handleClick}>
-              Select Biosample
-            </Button>
-          </Tooltip>
-        }
+        slotProps={{
+          toolbar: {
+            labelTooltip: "cCREs intersected against SNPs identified by selected GWAS study",
+            extra: (
+              <Tooltip title="Advanced Filters">
+                <Button variant="outlined" onClick={() => setOpen(true)}>
+                  Select Biosample
+                </Button>
+              </Tooltip>
+            ),
+          },
+        }}
       />
       <BiosampleSelectDialog
         assembly={entity.assembly}
-        open={Boolean(virtualAnchor)}
+        open={open}
         onClose={handleClickClose}
         onSelectionChange={handleBiosampleSelected}
         selected={selectedBiosample}

--- a/src/app/[assembly]/[entityType]/[entityID]/[[...tab]]/_GwasTabs/_Gene/GWASStudyGenes.tsx
+++ b/src/app/[assembly]/[entityType]/[entityID]/[[...tab]]/_GwasTabs/_Gene/GWASStudyGenes.tsx
@@ -123,33 +123,14 @@ export const GWASStudyGenes = ({ entity }: EntityViewComponentProps) => {
     method,
   });
 
-  //Not really sure how this works, but only way to anchor the popper since the extra toolbarSlot either gets unrendered or unmouted after
-  //setting the anchorEl to the button
-  const [virtualAnchor, setVirtualAnchor] = useState<{
-    getBoundingClientRect: () => DOMRect;
-  } | null>(null);
+  const [open, setOpen] = useState(false);
 
   const handleClickClose = () => {
-    if (virtualAnchor) {
-      setVirtualAnchor(null);
-    }
+    setOpen(false);
   };
 
   const handleMethodSelected = (method: string) => {
     setMethod(method);
-  };
-
-  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
-    if (virtualAnchor) {
-      // If already open, close it
-      setVirtualAnchor(null);
-    } else {
-      // Open it, store the current position
-      const rect = event.currentTarget.getBoundingClientRect();
-      setVirtualAnchor({
-        getBoundingClientRect: () => rect,
-      });
-    }
   };
 
   const HiCLinked = dataGWASSnpscCREsGenes?.filter((x) => x.assay === "Intact-HiC");
@@ -342,14 +323,18 @@ export const GWASStudyGenes = ({ entity }: EntityViewComponentProps) => {
             sortModel: [{ field: "score", sort: "desc" }],
           },
         }}
-        labelTooltip={"Only one method can be shown at a time — select a method by clicking the button to the right"}
-        toolbarSlot={
-          <Tooltip title="Advanced Filters">
-            <Button variant="outlined" onClick={handleClick}>
-              Select Method
-            </Button>
-          </Tooltip>
-        }
+        slotProps={{
+          toolbar: {
+            labelTooltip: "Only one method can be shown at a time — select a method by clicking the button to the right",
+            extra: (
+              <Tooltip title="Advanced Filters">
+                <Button variant="outlined" onClick={() => setOpen(true)}>
+                  Select Method
+                </Button>
+              </Tooltip>
+            ),
+          },
+        }}
         divHeight={{ height: "400px" }}
       />
       <Box
@@ -359,7 +344,7 @@ export const GWASStudyGenes = ({ entity }: EntityViewComponentProps) => {
       >
         <SelectCompuGenesMethod
           method={method}
-          open={Boolean(virtualAnchor)}
+          open={open}
           setOpen={handleClickClose}
           onMethodSelect={handleMethodSelected}
         />

--- a/src/app/[assembly]/[entityType]/[entityID]/[[...tab]]/_RegionTabs/_cCREs/IntersectingCcres.tsx
+++ b/src/app/[assembly]/[entityType]/[entityID]/[[...tab]]/_RegionTabs/_cCREs/IntersectingCcres.tsx
@@ -37,29 +37,10 @@ const IntersectingCcres = ({ entity }: EntityViewComponentProps) => {
     cellType: selectedBiosample ? selectedBiosample.name : undefined,
   });
 
-  //Not really sure how this works, but only way to anchor the popper since the extra toolbarSlot either gets unrendered or unmouted after
-  //setting the anchorEl to the button
-  const [virtualAnchor, setVirtualAnchor] = useState<{
-    getBoundingClientRect: () => DOMRect;
-  } | null>(null);
-
-  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
-    if (virtualAnchor) {
-      // If already open, close it
-      setVirtualAnchor(null);
-    } else {
-      // Open it, store the current position
-      const rect = event.currentTarget.getBoundingClientRect();
-      setVirtualAnchor({
-        getBoundingClientRect: () => rect,
-      });
-    }
-  };
+  const [open, setOpen] = useState(false);
 
   const handleClickClose = () => {
-    if (virtualAnchor) {
-      setVirtualAnchor(null);
-    }
+    setOpen(false);
   };
   const showAtac = !selectedBiosample || !!selectedBiosample.atac_experiment_accession;
   const showCTCF = !selectedBiosample || !!selectedBiosample.ctcf_experiment_accession;
@@ -244,19 +225,23 @@ const IntersectingCcres = ({ entity }: EntityViewComponentProps) => {
         error={!!errorCcres}
         label={`Intersecting cCREs`}
         emptyTableFallback={"No intersecting cCREs found in this region"}
-        toolbarSlot={
-          <Tooltip title="Advanced Filters">
-            <Button variant="outlined" onClick={handleClick}>
-              Select Biosample
-            </Button>
-          </Tooltip>
-        }
+        slotProps={{
+          toolbar: {
+            extra: (
+              <Tooltip title="Advanced Filters">
+                <Button variant="outlined" onClick={() => setOpen(true)}>
+                  Select Biosample
+                </Button>
+              </Tooltip>
+            ),
+          },
+        }}
         initialState={{ sorting: { sortModel: [{ field: "dnase", sort: "desc" }] } }}
         divHeight={{ maxHeight: "600px" }}
       />
       <BiosampleSelectDialog
         assembly={entity.assembly}
-        open={Boolean(virtualAnchor)}
+        open={open}
         onClose={handleClickClose}
         onSelectionChange={handleBiosampleSelected}
         selected={selectedBiosample}

--- a/src/app/[assembly]/[entityType]/[entityID]/[[...tab]]/_SnpTabs/_cCREs/VariantLinkedCcres.tsx
+++ b/src/app/[assembly]/[entityType]/[entityID]/[[...tab]]/_SnpTabs/_cCREs/VariantLinkedCcres.tsx
@@ -145,12 +145,16 @@ const VariantLinkedCcres = ({ entity }: EntityViewComponentProps) => {
         </Stack>
       }
       autoHeight
-      toolbarSlot={<DistanceSlider distance={distance} handleDistanceChange={handleDistanceChange} />}
-      labelTooltip={
-        <Typography component="span" variant="subtitle2">
-          (Within {distance}bp of {entity.entityID})
-        </Typography>
-      }
+      slotProps={{
+        toolbar: {
+          extra: <DistanceSlider distance={distance} handleDistanceChange={handleDistanceChange} />,
+          labelTooltip: (
+            <Typography component="span" variant="subtitle2">
+              (Within {distance}bp of {entity.entityID})
+            </Typography>
+          ),
+        },
+      }}
     />
   );
 };

--- a/src/app/api/graphql/route.ts
+++ b/src/app/api/graphql/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from "next/server";
+import Config from "common/config.json";
+
+export async function POST(request: NextRequest) {
+  const body = await request.text();
+
+  const response = await fetch(Config.API.CcreAPI, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "api-key": process.env.SCREEN_API_KEY!,
+    },
+    body,
+  });
+
+  const data = await response.text();
+  return new NextResponse(data, {
+    status: response.status,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/src/app/landing/mainSearch.tsx
+++ b/src/app/landing/mainSearch.tsx
@@ -79,16 +79,13 @@ const MainSearch: React.FC<MainSearchProps> = ({ assembly, handleAssemblyChange 
             sx={{ display: { xs: "flex", md: "flex" } }}
             style={{ width: "100%" }}
             slots={{
-              button: (
-                <IconButton sx={{ color: "white" }}>
-                  <Search />
-                </IconButton>
-              ),
+              button: IconButton,
             }}
             assembly={assembly}
             id="main-search-component"
             slotProps={{
               box: { gap: 1 },
+              button: { sx: { color: "white" }, children: <Search /> },
               input: {
                 size: "small",
                 label: `Enter a gene, cCRE${assembly === "GRCh38" ? ", variant, GWAS," : ""} or locus`,

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -165,13 +165,8 @@ export default function Page({
     queries: ["Gene", "cCRE", "SNP", "Coordinate", "Study", "Legacy cCRE"],
     assembly,
     geneVersion,
-    limits: {
-      gene: limit,
-      snp: limit,
-      icre: limit,
-      ccre: limit,
-      study: limit,
-    },
+    graphqlUrl: "/api/graphql",
+    limit: limit,
   });
 
   const grouped = data?.reduce<Record<string, Result[]>>((acc, r) => {

--- a/src/common/apollo/apollo-wrapper.tsx
+++ b/src/common/apollo/apollo-wrapper.tsx
@@ -8,13 +8,11 @@ import {
   SSRMultipartLink,
   ApolloClient,
 } from "@apollo/experimental-nextjs-app-support";
-import Config from "common/config.json";
-
 // See https://www.apollographql.com/blog/using-apollo-client-with-next-js-13-releasing-an-official-library-to-support-the-app-router
 
 export function makeClient() {
   const httpLink = new HttpLink({
-    uri: Config.API.CcreAPI,
+    uri: "/api/graphql",
   });
 
   return new ApolloClient({

--- a/src/common/apollo/client.ts
+++ b/src/common/apollo/client.ts
@@ -11,8 +11,9 @@ export const { getClient, query, PreloadQuery } = registerApolloClient(() => {
     cache: new InMemoryCache(),
     link: new HttpLink({
       uri: Config.API.CcreAPI,
-      // you can disable result caching here if you want to
-      // (this does not work if you are rendering your page with `export const dynamic = "force-static"`)
+      headers: {
+        "api-key": process.env.SCREEN_API_KEY!,
+      },
     }),
   });
 });

--- a/src/common/components/ClientAppWrapper.tsx
+++ b/src/common/components/ClientAppWrapper.tsx
@@ -10,7 +10,7 @@ export default function ClientAppWrapper({ children }: { children: React.ReactNo
   useEffect(() => {
     const checkAPIHealth = async () => {
       try {
-        const res = await fetch("https://screen.api.wenglab.org/graphql", {
+        const res = await fetch("/api/graphql", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ query: "{ __typename }" }),

--- a/src/common/components/GenomeBrowser/GenomeBrowserView.tsx
+++ b/src/common/components/GenomeBrowser/GenomeBrowserView.tsx
@@ -171,18 +171,18 @@ export default function GenomeBrowserView({
               size="small"
               assembly={entity.assembly}
               geneVersion={geneVersion}
+              graphqlUrl="/api/graphql"
               onSearchSubmit={handeSearchSubmit}
               queries={["Gene", "SNP", "cCRE", "Coordinate"]}
-              geneLimit={3}
               sx={{ width: "100%" }}
               slots={{
-                button: (
-                  <IconButton sx={{ color: theme.palette.primary.main }}>
-                    <Search />
-                  </IconButton>
-                ),
+                button: IconButton,
               }}
               slotProps={{
+                button: {
+                  sx: { color: theme.palette.primary.main },
+                  children: <Search />,
+                },
                 input: {
                   label: "Change Browser Region",
                   sx: {

--- a/src/common/components/Header/Header.tsx
+++ b/src/common/components/Header/Header.tsx
@@ -278,15 +278,12 @@ function Header({ maintenance }: ResponsiveAppBarProps) {
                 style={{ width: 400 }}
                 id="desktop-search-component"
                 slots={{
-                  button: (
-                    <IconButton sx={{ color: "white" }}>
-                      <Search />
-                    </IconButton>
-                  ),
+                  button: IconButton,
                 }}
                 assembly={assembly}
                 slotProps={{
                   box: { gap: 1 },
+                  button: { sx: { color: "white" }, children: <Search /> },
                   input: {
                     size: "small",
                     label: `Enter a gene, cCRE${assembly === "GRCh38" ? ", variant" : ""} or locus`,

--- a/src/common/components/Header/MobileMenu.tsx
+++ b/src/common/components/Header/MobileMenu.tsx
@@ -69,14 +69,15 @@ export default function MobileMenu({ pageLinks }: MobileMenuProps) {
               closeDrawer={handleCloseDrawer}
               assembly={assembly}
               slots={{
-                button: (
-                  <IconButton sx={{ color: "black" }}>
-                    <Search />
-                  </IconButton>
-                ),
+                button: IconButton,
               }}
               slotProps={{
                 box: { gap: 1 },
+                button: {
+                  onClick: handleCloseDrawer,
+                  sx: { color: "black" },
+                  children: <Search />,
+                },
                 input: {
                   size: "small",
                   label: `Enter a gene, cCRE${assembly === "GRCh38" ? ", variant" : ""} or locus`,
@@ -85,9 +86,6 @@ export default function MobileMenu({ pageLinks }: MobileMenuProps) {
                       backgroundColor: "#ffffff",
                     },
                   },
-                },
-                button: {
-                  onClick: handleCloseDrawer,
                 },
               }}
             />

--- a/src/common/components/autocomplete.tsx
+++ b/src/common/components/autocomplete.tsx
@@ -141,7 +141,7 @@ export default function AutoComplete({ closeDrawer, ...props }: AutoCompleteProp
     <GenomeSearch
       assembly={props.assembly}
       geneVersion={geneVersion}
-      ccreLimit={3}
+      graphqlUrl="api/graphql"
       showiCREFlag={false}
       queries={["Gene", "cCRE", "SNP", "Coordinate", "Study", "Legacy cCRE"]}
       onSearchSubmit={handleSearchSubmit}

--- a/src/common/components/autocomplete.tsx
+++ b/src/common/components/autocomplete.tsx
@@ -141,7 +141,7 @@ export default function AutoComplete({ closeDrawer, ...props }: AutoCompleteProp
     <GenomeSearch
       assembly={props.assembly}
       geneVersion={geneVersion}
-      graphqlUrl="api/graphql"
+      graphqlUrl="/api/graphql"
       showiCREFlag={false}
       queries={["Gene", "cCRE", "SNP", "Coordinate", "Study", "Legacy cCRE"]}
       onSearchSubmit={handleSearchSubmit}

--- a/src/common/entityTabsConfig/entityTabsConfig.ts
+++ b/src/common/entityTabsConfig/entityTabsConfig.ts
@@ -120,7 +120,7 @@ export const humanGeneTabs = [
   },
   {
     route: "transcript-expression",
-    label: "Transcript Expression",
+    label: "",
     component: TranscriptExpression,
   },
 ] as const satisfies TabConfig[];

--- a/src/common/entityTabsConfig/entityTabsConfig.ts
+++ b/src/common/entityTabsConfig/entityTabsConfig.ts
@@ -120,7 +120,7 @@ export const humanGeneTabs = [
   },
   {
     route: "transcript-expression",
-    label: "",
+    label: "Transcript Expression",
     component: TranscriptExpression,
   },
 ] as const satisfies TabConfig[];


### PR DESCRIPTION
Adds functionality for adding key in header of all requests going to our gateway. Upgrade to v3 of ui-components allows GenomeSearch to use the newly created `api/graphql` route