### PR TITLE
Mask CPG by Coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@types/node": "^22",
     "@vercel/analytics": "^1.6.1",
     "@visx/visx": "^3",
-    "@weng-lab/genomebrowser": "1.8.5-beta.0",
+    "@weng-lab/genomebrowser": "1.8.5-beta.4",
     "@weng-lab/genomebrowser-ui": "0.3.6",
     "@weng-lab/ui-components": "3.0.0",
     "@weng-lab/visualization": "1.3.2",

--- a/src/common/components/GenomeBrowser/TrackSelect/TrackSelectModal.tsx
+++ b/src/common/components/GenomeBrowser/TrackSelect/TrackSelectModal.tsx
@@ -247,6 +247,7 @@ function generateTrack(
         id: sel.id,
         title,
         range: { min: 0, max: 100 },
+        maskCpgByCoverage: true,
         urls: {
           plusStrand: {
             cpg: { url: sel.cpgPlus ?? "" },


### PR DESCRIPTION
WGBS tracks now only show CPG when there is coverage on that position