### PR TITLE
Fix safari/mobile downloads issue

### DIFF
--- a/src/app/downloads/Annotations/Annotations.tsx
+++ b/src/app/downloads/Annotations/Annotations.tsx
@@ -47,7 +47,7 @@ const Annotations = () => {
   const [assembly, tab] = selectedTab.split("/") as [Assembly, string];
 
   return (
-    <Box display={"grid"} height={"stretch"} gridTemplateRows={"1fr auto"} gap={2}>
+    <Box height={'100%'} display={"grid"} gridTemplateRows={"1fr auto"} gap={2} id="annotations">
       <Box
         display={"grid"}
         gridTemplateColumns={{ xs: "auto", md: "auto 1fr" }}

--- a/src/app/downloads/page.tsx
+++ b/src/app/downloads/page.tsx
@@ -27,11 +27,11 @@ export default function Downloads() {
       gridTemplateRows={"auto 1fr"}
       height={"100%"}
       boxSizing={"border-box"}
-      sx={{ marginX: "5%", paddingY: 2 }}
+      sx={{ p: 2 }}
       gap={2}
       id="downloads"
     >
-      <Box id="downloads-tabs">
+      <Box id="downloads-tabs" minWidth={0}>
         <Tabs
           value={page}
           onChange={handleChange}

--- a/src/app/downloads/page.tsx
+++ b/src/app/downloads/page.tsx
@@ -24,19 +24,25 @@ export default function Downloads() {
   return (
     <Box
       display={"grid"}
-      height={"stretch"}
       gridTemplateRows={"auto 1fr"}
-      boxSizing={"content-box"}
-      sx={{ marginX: "5%", marginY: 2 }}
+      height={"100%"}
+      boxSizing={"border-box"}
+      sx={{ marginX: "5%", paddingY: 2 }}
       gap={2}
+      id="downloads"
     >
-      <Box>
+      <Box id="downloads-tabs">
         <Tabs
           value={page}
           onChange={handleChange}
           aria-label="basic tabs example"
           variant="scrollable"
           allowScrollButtonsMobile
+          sx={{
+            "& .MuiTabs-scrollButtons.Mui-disabled": {
+              opacity: 0.3,
+            },
+          }}
         >
           <Tab label="Annotations" {...a11yProps(0)} />
           <Tab label="Data Matrices" {...a11yProps(1)} />
@@ -44,7 +50,7 @@ export default function Downloads() {
         </Tabs>
         <Divider />
       </Box>
-      <Box minWidth={0} minHeight={0}>
+      <Box minWidth={0} minHeight={0} id="downloads-content">
         {page === 0 && <Annotations />}
         {page === 1 && <DataMatrices />}
         {page === 2 && <DownloadRange />}


### PR DESCRIPTION
Not just mobile, but safari had the footer overlap issue as well (chrome on ios is webkit based like safari). Fix was moving away from `height: stretch` which webkit does not resolve the same as chromium

Also, switch to uniform theme.spacing(2) padding all around to match rest of app (Previously X axis had 5%) and provide `minWidth: 0` on tabs to allow shrinking down properly on mobile