### PR TITLE
Fix cCRE track tooltip + Data Matrices column modification issue

### DIFF
--- a/src/app/downloads/Annotations/Annotations.tsx
+++ b/src/app/downloads/Annotations/Annotations.tsx
@@ -9,6 +9,7 @@ import { TreeItem, TreeItemProps } from "@mui/x-tree-view";
 import AnnotationsOtherOrthologous from "./AnnotationsOtherOrthologous";
 import AnnotationsContactUs from "./AnnotationsContactUs";
 import AnnotationsFunctional from "./AnnotationsFunctional";
+import AnnotationsGeneExpression from "./AnnotationsGeneExpression";
 
 const StyledTreeItem = styled(TreeItem)<TreeItemProps>(({ theme }) => ({
   "& .MuiTreeItem-label": {
@@ -39,6 +40,8 @@ const Content = ({ tab, assembly }: { tab: string; assembly: Assembly }) => {
       return <AnnotationsOtherOrthologous />;
     case "functional":
       return <AnnotationsFunctional assembly={assembly} />;
+    case "geneExpression":
+      return <AnnotationsGeneExpression assembly={assembly} />;
   }
 };
 
@@ -66,11 +69,13 @@ const Annotations = () => {
             <StyledTreeItem itemId="GRCh38/byCelltype" label="cCREs by Cell and Tissue Type" />
             <StyledTreeItem itemId="GRCh38/geneLinks" label="cCRE-Gene Links" />
             <StyledTreeItem itemId="GRCh38/functional" label="Functional Characterization" />
+            <StyledTreeItem itemId="GRCh38/geneExpression" label="Gene Expression" />
           </StyledTreeItem>
           <StyledTreeItem className="tree-category" itemId="mouse" label="Mouse">
             <StyledTreeItem itemId="mm10/byClass" label="cCREs by Class" />
             <StyledTreeItem itemId="mm10/byCelltype" label="cCREs by Cell and Tissue Type" />
             <StyledTreeItem itemId="mm10/functional" label="Functional Characterization" />
+            <StyledTreeItem itemId="mm10/geneExpression" label="Gene Expression" />
           </StyledTreeItem>
           <StyledTreeItem className="tree-category" itemId="other" label="Other">
             <StyledTreeItem itemId="other/ortho" label="Orthologous cCREs" />

--- a/src/app/downloads/Annotations/AnnotationsGeneExpression.tsx
+++ b/src/app/downloads/Annotations/AnnotationsGeneExpression.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import Config from "common/config.json";
+import { DownloadButton, DownloadButtonProps } from "./DownloadButton";
+import DownloadContentLayout from "./DownloadContentLayout";
+import { Assembly } from "./Annotations";
+
+const classDownloads: {
+  GRCh38: DownloadButtonProps[];
+  mm10: DownloadButtonProps[];
+} = {
+  GRCh38: [
+    {
+      href: Config.Downloads.HumanGeneExpression,
+      label: "Gene Expression TPM Matrix",
+      fileSize: "21.8 MB",
+      bordercolor: "gray",
+    }
+  ],
+  mm10: [
+    {
+      href: Config.Downloads.MouseGeneExpression,
+      label: "Gene Expression TPM Matrix",
+      fileSize: "9 MB",
+      bordercolor: "gray",
+    },
+  ],
+};
+
+interface AnnotationsGeneExpression {
+  assembly: Assembly;
+}
+
+const AnnotationsGeneExpression: React.FC<AnnotationsGeneExpression> = ({ assembly }) => {
+  return (
+    <DownloadContentLayout title="Gene Expression">
+      {classDownloads[assembly].map((item) => (
+        <DownloadButton key={item.label} {...item} assembly={assembly} />
+      ))}
+    </DownloadContentLayout>
+  );
+};
+
+export default AnnotationsGeneExpression;

--- a/src/app/downloads/DataMatricies/DataMatricies.tsx
+++ b/src/app/downloads/DataMatricies/DataMatricies.tsx
@@ -177,14 +177,21 @@ export function DataMatrices() {
     }
   };
 
-  const columnVisibilityModel: GridColumnVisibilityModel = useMemo(
-    () => ({
+  const [columnVisibilityModel, setColumnVisibilityModel] = useState<GridColumnVisibilityModel>(() => ({
+    ...allColsHidden,
+    assays: true,
+    [`${selectedAssay.assay.toLowerCase()}_experiment_accession`]: true,
+  }));
+
+  // Keep the visible accession column in sync with the selected assay.
+  // Note: switching assays resets any manual column modifications the user made.
+  useEffect(() => {
+    setColumnVisibilityModel({
       ...allColsHidden,
       assays: true,
       [`${selectedAssay.assay.toLowerCase()}_experiment_accession`]: true,
-    }),
-    [selectedAssay]
-  );
+    });
+  }, [selectedAssay]);
 
   return (
     <Box
@@ -328,6 +335,7 @@ export function DataMatrices() {
           selected={selectedBiosamples}
           prefilterBiosamples={(biosample) => biosampleHasAssay(biosample, selectedAssay.assay)}
           columnVisibilityModel={columnVisibilityModel}
+          onColumnVisibilityModelChange={setColumnVisibilityModel}
           // temporary fix while other tables are not setup to group rows
           disableRowGrouping={false}
           divHeight={{ height: 750 }}

--- a/src/common/components/GenomeBrowser/Tooltips/CcreTooltip.tsx
+++ b/src/common/components/GenomeBrowser/Tooltips/CcreTooltip.tsx
@@ -1,47 +1,18 @@
-import { useQuery } from "@apollo/client/react";
-import { gql } from "common/types/generated";
 import { CLASS_COLORS } from "common/ccre";
 import { CLASS_DESCRIPTIONS } from "common/ccre";
 import { CcreTooltipBiosample } from "../TrackSelect/defaultTracks";
+import { useCcreZScores } from "common/hooks/data/ccre";
+import { Assembly } from "common/types/globalTypes";
 import { useMemo } from "react";
 
 interface CCRETooltipProps {
-  assembly: string;
+  assembly: Assembly;
   name: string;
   biosample?: CcreTooltipBiosample;
 }
 
-const BIOSAMPLE_QUERY = gql(`
-  query cCREBiosampleTooltip($assembly: String!, $biosampleName: [String!], $accession: [String!]) {
-    ccREBiosampleQuery(assembly: $assembly, name: $biosampleName) {
-      biosamples {
-        name
-        displayname
-        cCREZScores(accession: $accession) {
-          assay
-          score
-          experiment_accession
-        }
-      }
-    }
-  }
-`);
-
-const MAXZ_QUERY = gql(`
-  query cCRE_2($assembly: String!, $accession: [String!]) {
-    cCREQuery(assembly: $assembly, accession: $accession) {
-      group
-      dnase: maxZ(assay: "dnase")
-      h3k4me3: maxZ(assay: "h3k4me3")
-      h3k27ac: maxZ(assay: "h3k27ac")
-      ctcf: maxZ(assay: "ctcf")
-      atac: maxZ(assay: "atac")
-    }
-  }
-`);
-
 const MARKS = ["DNase", "H3K4me3", "H3K27ac", "CTCF", "ATAC"];
-const ASSAY_ORDER = ["dnase", "h3k4me3", "h3k27ac", "ctcf", "atac"];
+const ASSAY_ORDER = ["dnase", "h3k4me3", "h3k27ac", "ctcf", "atac"] as const;
 
 function truncate(text: string, maxLength: number) {
   if (text.length <= maxLength) return text;
@@ -49,58 +20,32 @@ function truncate(text: string, maxLength: number) {
 }
 
 export default function CCRETooltip({ assembly, name, biosample }: CCRETooltipProps) {
-  const {
-    data: ccreData,
-    loading: ccreLoading,
-    error: ccreError,
-  } = useQuery(MAXZ_QUERY, {
-    variables: {
-      assembly,
-      accession: [name],
-    },
-  });
-  const {
-    data: biosampleData,
-    loading: biosampleLoading,
-    error: biosampleError,
-  } = useQuery(BIOSAMPLE_QUERY, {
-    variables: {
-      assembly: assembly.toLowerCase(),
-      accession: [name],
-      biosampleName: biosample?.name ? [biosample.name] : undefined,
-    },
-    skip: !biosample,
+  // Scores and group come from a single call: biosample-agnostic max-Z + global group when no
+  // biosample is passed, biosample-specific z-scores + classification when one is (see useCcreZScores).
+  const { data, loading, error } = useCcreZScores({
+    accessions: [name],
+    assembly,
+    biosample: biosample?.name,
   });
 
-  const biosampleScores = useMemo(() => {
-    if (!biosample) return [];
+  const ccre = data?.[name];
 
-    const zScores = biosampleData?.ccREBiosampleQuery?.biosamples?.[0]?.cCREZScores ?? [];
-
-    return ASSAY_ORDER.flatMap((assay, index) => {
-      const score = zScores.find((entry) => entry?.assay?.toLowerCase() === assay)?.score;
-      return score == null ? [] : [{ label: MARKS[index], score: score.toFixed(2) }];
-    });
-  }, [biosample, biosampleData]);
-
-  const maxZSscores = useMemo(() => {
-    if (biosample || !ccreData?.cCREQuery?.[0]) return [];
+  const scoreRows = useMemo(() => {
+    if (!ccre) return [];
 
     return ASSAY_ORDER.flatMap((assay, index) => {
-      const score = ccreData.cCREQuery[0][assay];
+      const score = ccre[assay];
       return score == null ? [] : [{ label: MARKS[index], score: score.toFixed(2) }];
     });
-  }, [biosample, ccreData]);
+  }, [ccre]);
 
-  if (ccreError || biosampleError) {
+  if (error) {
     return null;
   }
 
-  const loading = ccreLoading || (biosample ? biosampleLoading : false);
-
-  const scoreRows = biosample ? biosampleScores : maxZSscores;
-  const biosampleDisplayName = biosampleData?.ccREBiosampleQuery?.biosamples?.[0]?.displayname ?? biosample?.displayname;
-  const hasData = !!ccreData?.cCREQuery?.[0] && (!biosample || !!biosampleData?.ccREBiosampleQuery?.biosamples?.[0]);
+  const group = ccre?.group;
+  const hasData = !!ccre;
+  const biosampleDisplayName = biosample?.displayname;
   const width = 236;
   const padding = 10;
   const compactLineHeight = 16;
@@ -152,13 +97,13 @@ export default function CCRETooltip({ assembly, name, biosample }: CCRETooltipPr
             y={10}
             width={10}
             height={10}
-            fill={CLASS_COLORS[ccreData?.cCREQuery?.[0]?.group] ?? "#8c8c8c"}
+            fill={group ? CLASS_COLORS[group] : "#8c8c8c"}
           />
           <text x={padding + 16} y={titleY} fontSize={12} fontWeight="bold" fill="#000000">
             {name}
           </text>
           <text x={padding} y={groupY} fontSize={12} fill="#000000">
-            {CLASS_DESCRIPTIONS[ccreData?.cCREQuery?.[0]?.group]}
+            {group ? CLASS_DESCRIPTIONS[group] : ""}
           </text>
           <text x={padding} y={hintY} fontSize={12} fill="#666666">
             Click for details about this cCRE

--- a/src/common/components/GenomeBrowser/Tooltips/CcreTooltip.tsx
+++ b/src/common/components/GenomeBrowser/Tooltips/CcreTooltip.tsx
@@ -20,8 +20,6 @@ function truncate(text: string, maxLength: number) {
 }
 
 export default function CCRETooltip({ assembly, name, biosample }: CCRETooltipProps) {
-  // Scores and group come from a single call: biosample-agnostic max-Z + global group when no
-  // biosample is passed, biosample-specific z-scores + classification when one is (see useCcreZScores).
   const { data, loading, error } = useCcreZScores({
     accessions: [name],
     assembly,

--- a/src/common/config.json
+++ b/src/common/config.json
@@ -28,6 +28,7 @@
     "HumanGeneLinksGraphRegLR": "https://downloads.wenglab.org/V4-hg38.Gene-Links.Computational-Methods.GraphRegLR.txt.gz",
     "HumanGeneLinksrE2G": "https://downloads.wenglab.org/V4-hg38.Gene-Links.Computational-Methods.rE2G.txt.gz",
     "HumanNearestPC": "https://downloads.wenglab.org/GRCh38-Closest-Genes-PC.tsv",
+    "HumanGeneExpression" : "https://downloads.wenglab.org/human_gene_expression_files.tar.gz",
     "HumanNearestAll": "https://downloads.wenglab.org/GRCh38-Closest-Genes-All.tsv",
     "HumanCAPRA": "https://downloads.wenglab.org/human_capra_functional_characterization.tar.gz",
     "HumanMPRA": "https://downloads.wenglab.org/human_mpra_functional_characterization.tar.gz",
@@ -51,6 +52,8 @@
     "MouseVISTA": "https://downloads.wenglab.org/VISTA-mm10.04-22-2023.bed",
 
     "HumanMouseOrtholog": "https://downloads.wenglab.org/hg38-mm10-Homologous.tsv",
+
+    "MouseGeneExpression" : "https://downloads.wenglab.org/mouse_gene_expression_files.tar.gz",
 
     "HumanDNaseSignalMatrix": "https://www.encodeproject.org/files/ENCFF434ORT/@@download/ENCFF434ORT.txt.gz",
     "HumanPromoterSignalMatrix": "https://www.encodeproject.org/files/ENCFF015SIE/@@download/ENCFF015SIE.txt.gz",

--- a/src/common/hooks/data/ccre/useCcreZScores.ts
+++ b/src/common/hooks/data/ccre/useCcreZScores.ts
@@ -86,16 +86,21 @@ export const useCcreZScores = ({
           ? parseZScoresArray(entry.zscores as ZScoresEntry<null>[])
           : undefined;
 
+        // When a biosample is selected, scores and classification come solely from its
+        // biosample-specific z-scores; an assay the biosample did not perform stays absent
+        // rather than falling back to the biosample-agnostic max (see fetchCcreDownloadData).
         return [
           [
             entry.accession,
             {
-              dnase: zScores?.dnase ?? entry.dnase_max_zscore,
-              atac: zScores?.atac ?? entry.atac_max_zscore,
-              h3k4me3: zScores?.h3k4me3 ?? entry.h3k4me3_max_zscore,
-              h3k27ac: zScores?.h3k27ac ?? entry.h3k27ac_max_zscore,
-              ctcf: zScores?.ctcf ?? entry.ctcf_max_zscore,
-              group: zScores ? classifyCcre(zScores, zScores.tf, distance) : (entry.ccre_group as CcreClass),
+              dnase: biosample ? zScores?.dnase : entry.dnase_max_zscore ?? undefined,
+              atac: biosample ? zScores?.atac : entry.atac_max_zscore ?? undefined,
+              h3k4me3: biosample ? zScores?.h3k4me3 : entry.h3k4me3_max_zscore ?? undefined,
+              h3k27ac: biosample ? zScores?.h3k27ac : entry.h3k27ac_max_zscore ?? undefined,
+              ctcf: biosample ? zScores?.ctcf : entry.ctcf_max_zscore ?? undefined,
+              group: biosample
+                ? classifyCcre(zScores ?? {}, zScores?.tf ?? false, distance)
+                : (entry.ccre_group as CcreClass),
             },
           ],
         ];

--- a/src/common/hooks/data/ccre/useCcreZScores.ts
+++ b/src/common/hooks/data/ccre/useCcreZScores.ts
@@ -86,9 +86,6 @@ export const useCcreZScores = ({
           ? parseZScoresArray(entry.zscores as ZScoresEntry<null>[])
           : undefined;
 
-        // When a biosample is selected, scores and classification come solely from its
-        // biosample-specific z-scores; an assay the biosample did not perform stays absent
-        // rather than falling back to the biosample-agnostic max (see fetchCcreDownloadData).
         return [
           [
             entry.accession,

--- a/src/common/hooks/data/ccre/useIntersectingCcreZScores.ts
+++ b/src/common/hooks/data/ccre/useIntersectingCcreZScores.ts
@@ -97,9 +97,6 @@ export const useIntersectingCcreZScores = ({
         ? parseZScoresArray(entry.zscores as ZScoresEntry<null>[])
         : undefined;
 
-      // When a biosample is selected, scores and classification come solely from its
-      // biosample-specific z-scores; an assay the biosample did not perform stays absent
-      // rather than falling back to the biosample-agnostic max (see fetchCcreDownloadData).
       return [
         {
           accession: entry.accession,

--- a/src/common/hooks/data/ccre/useIntersectingCcreZScores.ts
+++ b/src/common/hooks/data/ccre/useIntersectingCcreZScores.ts
@@ -97,6 +97,9 @@ export const useIntersectingCcreZScores = ({
         ? parseZScoresArray(entry.zscores as ZScoresEntry<null>[])
         : undefined;
 
+      // When a biosample is selected, scores and classification come solely from its
+      // biosample-specific z-scores; an assay the biosample did not perform stays absent
+      // rather than falling back to the biosample-agnostic max (see fetchCcreDownloadData).
       return [
         {
           accession: entry.accession,
@@ -105,12 +108,14 @@ export const useIntersectingCcreZScores = ({
             start: entry.start,
             end: entry.stop,
           },
-          dnase: zScores?.dnase ?? entry.dnase_max_zscore,
-          atac: zScores?.atac ?? entry.atac_max_zscore,
-          h3k4me3: zScores?.h3k4me3 ?? entry.h3k4me3_max_zscore,
-          h3k27ac: zScores?.h3k27ac ?? entry.h3k27ac_max_zscore,
-          ctcf: zScores?.ctcf ?? entry.ctcf_max_zscore,
-          group: zScores ? classifyCcre(zScores, zScores.tf, distance) : (entry.ccre_group as CcreClass),
+          dnase: biosample ? zScores?.dnase : entry.dnase_max_zscore ?? undefined,
+          atac: biosample ? zScores?.atac : entry.atac_max_zscore ?? undefined,
+          h3k4me3: biosample ? zScores?.h3k4me3 : entry.h3k4me3_max_zscore ?? undefined,
+          h3k27ac: biosample ? zScores?.h3k27ac : entry.h3k27ac_max_zscore ?? undefined,
+          ctcf: biosample ? zScores?.ctcf : entry.ctcf_max_zscore ?? undefined,
+          group: biosample
+            ? classifyCcre(zScores ?? {}, zScores?.tf ?? false, distance)
+            : (entry.ccre_group as CcreClass),
         },
       ];
     });


### PR DESCRIPTION
Fix #357 - Note: not able to show biosample specific scores for biosample ccre tracks - needs GB adjustment to expose value used for querying. Showing max z for all
Fix #356 