### PR TITLE
SEO + crawler improvements

### DIFF
--- a/src/app/about/_Sections/AboutHeader.tsx
+++ b/src/app/about/_Sections/AboutHeader.tsx
@@ -4,7 +4,7 @@ export default function AboutHeader() {
   return (
     <Stack component="header" spacing={1}>
       <Box>
-        <Typography variant="h2" fontWeight={500}>
+        <Typography variant="h2" component="h1" fontWeight={500}>
           About SCREEN
         </Typography>
         <Divider />

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -10,14 +10,6 @@ import HowToCite from "./_Sections/HowToCite";
 import RegistryOfCcres from "./_Sections/RegistryOfCcres";
 import SiteVersions from "./_Sections/SiteVersions";
 
-/**
- * This is a server component: every section here is static composition, and the only
- * interactive one (ContactForm) declares its own "use client". MUI ships client boundaries on
- * its own components, so <Stack> and friends need nothing from this file.
- *
- * Keep it that way -- adding a hook here pulls the whole section tree back into the client
- * bundle and makes this metadata export illegal.
- */
 export const metadata = pageMetadata({
   title: "About the ENCODE Registry of cCREs",
   description:

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,6 +1,5 @@
-"use client";
-
 import { Stack } from "@mui/material";
+import { pageMetadata } from "common/seo";
 import AboutHeader from "./_Sections/AboutHeader";
 import ApiDocumentation from "./_Sections/ApiDocumentation";
 import CcreCollections from "./_Sections/CcreCollections";
@@ -10,6 +9,21 @@ import EncodeIntegration from "./_Sections/EncodeIntegration";
 import HowToCite from "./_Sections/HowToCite";
 import RegistryOfCcres from "./_Sections/RegistryOfCcres";
 import SiteVersions from "./_Sections/SiteVersions";
+
+/**
+ * This is a server component: every section here is static composition, and the only
+ * interactive one (ContactForm) declares its own "use client". MUI ships client boundaries on
+ * its own components, so <Stack> and friends need nothing from this file.
+ *
+ * Keep it that way -- adding a hook here pulls the whole section tree back into the client
+ * bundle and makes this metadata export illegal.
+ */
+export const metadata = pageMetadata({
+  title: "About the ENCODE Registry of cCREs",
+  description:
+    "How SCREEN and the ENCODE Registry of candidate cis-regulatory elements are built: cCRE classifications and collections, ENCODE integration, API access, and how to cite the resource.",
+  path: "/about",
+});
 
 export default function About() {
   return (

--- a/src/app/about/versions/ReleaseContent.tsx
+++ b/src/app/about/versions/ReleaseContent.tsx
@@ -4,7 +4,7 @@ import CloseIcon from "@mui/icons-material/Close";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import { Box, IconButton, Link, Modal, Stack, Typography } from "@mui/material";
 import { useState } from "react";
-import { ReleaseNote } from "./releaseNotes";
+import { formatReleaseDate, ReleaseNote } from "./releaseNotes";
 
 type ReleaseContentProps = {
   release: ReleaseNote;
@@ -155,7 +155,7 @@ const ReleaseContent = ({ release }: ReleaseContentProps) => {
           </Typography>
         </Box>
         <Typography variant="body2" sx={{ color: "grey.600" }}>
-          {release.date}
+          {formatReleaseDate(release.date)}
         </Typography>
       </Stack>
       <Typography variant="h5" sx={{ mb: release.summary ? 0.5 : 2, fontWeight: 600 }}>

--- a/src/app/about/versions/VersionHistoryBar.tsx
+++ b/src/app/about/versions/VersionHistoryBar.tsx
@@ -7,7 +7,7 @@ import TimelineDot from "@mui/lab/TimelineDot";
 import TimelineItem from "@mui/lab/TimelineItem";
 import TimelineSeparator from "@mui/lab/TimelineSeparator";
 import { Box, Stack, Typography } from "@mui/material";
-import { ReleaseNote } from "./releaseNotes";
+import { formatReleaseDate, ReleaseNote } from "./releaseNotes";
 
 type VersionHistoryBarProps = {
   releases: ReleaseNote[];
@@ -125,7 +125,7 @@ const VersionHistoryBar = ({ releases, selectedReleaseId, onSelect }: VersionHis
                       </Typography>
                     </Box>
                     <Typography variant="body2" sx={{ color: isSelected ? "primary.main" : "grey.600" }}>
-                      {release.date}
+                      {formatReleaseDate(release.date)}
                     </Typography>
                   </Stack>
                   <Typography variant="body2" sx={{ color: isSelected ? "primary.main" : "grey.600" }}>

--- a/src/app/about/versions/page.tsx
+++ b/src/app/about/versions/page.tsx
@@ -1,6 +1,15 @@
 import { Box, Stack, Typography } from "@mui/material";
+import { pageMetadata } from "common/seo";
 import LegacyVersionsModal from "./LegacyVersionsModal";
 import VersionsLayout from "./VersionsLayout";
+
+/** Overrides the /about metadata inherited from the parent layout. */
+export const metadata = pageMetadata({
+  title: "Release Notes",
+  description:
+    "Release notes for SCREEN: what's new, improved, and updated in each version of the site and the ENCODE Registry of candidate cis-regulatory elements.",
+  path: "/about/versions",
+});
 
 export default function VersionHistory() {
   return (
@@ -15,7 +24,9 @@ export default function VersionHistory() {
       >
         <Stack direction="row" justifyContent="space-between" alignItems="center" spacing={2}>
           <Box>
-            <Typography variant="h4">Release Notes</Typography>
+            <Typography variant="h4" component="h1">
+              Release Notes
+            </Typography>
             <Typography variant="subtitle2" color="text.secondary">
               Track what&apos;s new, improved, and updated across each release.
             </Typography>

--- a/src/app/about/versions/releaseNotes.tsx
+++ b/src/app/about/versions/releaseNotes.tsx
@@ -28,10 +28,75 @@ export type ReleaseNoteSection = {
   children?: ReleaseNoteChild[];
 };
 
+/**
+ * Machine-readable release date: zero-padded `YYYY-MM-DD` where the exact day is known, or a
+ * bare `YYYY` for legacy releases that predate exact dating.
+ *
+ * Stored in this shape rather than as display text ("25 June 2026") because sitemap.ts feeds it
+ * to `lastModified`, and prose dates only survive `new Date`'s implementation-defined fallback
+ * parser. Render it with `formatReleaseDate` -- nothing should display this value raw.
+ *
+ * The template literal constrains shape, not meaning: it still admits "2026-6-5" and
+ * "2026-13-45". `parseReleaseDay` is what actually validates.
+ */
+export type ReleaseDate = `${number}-${number}-${number}` | `${number}`;
+
+const MONTH_NAMES = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+];
+
+/**
+ * Splits a full-day `ReleaseDate` into calendar parts, or returns null for year-only entries and
+ * for values the template literal type can't rule out -- unpadded ("2026-6-5"), out of range
+ * ("2026-13-45"), or nonexistent ("2026-02-30").
+ */
+export function parseReleaseDay(date: ReleaseDate): { year: number; month: number; day: number } | null {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(date);
+  if (!match) return null;
+
+  const [year, month, day] = match.slice(1).map(Number);
+
+  // Round-trip through UTC to reject days the calendar doesn't have; Date silently rolls those
+  // forward (Feb 30 -> Mar 2) rather than failing.
+  const utc = new Date(Date.UTC(year, month - 1, day));
+  if (utc.getUTCFullYear() !== year || utc.getUTCMonth() !== month - 1 || utc.getUTCDate() !== day) {
+    return null;
+  }
+
+  return { year, month, day };
+}
+
+/**
+ * Renders a `ReleaseDate` for display: "25 June 2026", or the year alone for legacy year-only
+ * entries. Anything that slipped past `ReleaseDate` unvalidated falls back to the raw string, so
+ * a malformed entry shows up in the UI instead of throwing.
+ *
+ * Month names come from a table rather than `toLocaleDateString` so that this renders identically
+ * on the server and in the browser, without depending on either one's ICU data.
+ */
+export function formatReleaseDate(date: ReleaseDate): string {
+  const parsed = parseReleaseDay(date);
+  if (!parsed) return date;
+
+  return `${parsed.day} ${MONTH_NAMES[parsed.month - 1]} ${parsed.year}`;
+}
+
 export type ReleaseNote = {
   id: string;
   version: string;
-  date: string;
+  /** Machine-readable -- see {@link ReleaseDate}. Display it with {@link formatReleaseDate}. */
+  date: ReleaseDate;
   title: string;
   /** One-line summary of the release. Shown as a subheader below the title, and used by the homepage banner for the most recent release. */
   summary?: string;
@@ -42,7 +107,7 @@ export const RELEASE_NOTES: ReleaseNote[] = [
   {
     id: "r3.2026.2",
     version: "r3.2026.2",
-    date: "25 June 2026",
+    date: "2026-06-25",
     title: "June 2026 Release",
     summary: "Public API Access, 240 Mammal Conservation Simplex + Alignment, and sitewide improvements",
     sections: [
@@ -122,7 +187,7 @@ export const RELEASE_NOTES: ReleaseNote[] = [
   {
     id: "r3.2026.1",
     version: "r3.2026.1",
-    date: "30 April 2026",
+    date: "2026-04-30",
     title: "April 2026 Release",
     summary: "ChIP-seq peaks, PhastCons scores, CpG coverage, and promoter cCREs",
     sections: [

--- a/src/app/downloads/layout.tsx
+++ b/src/app/downloads/layout.tsx
@@ -1,0 +1,16 @@
+import { pageMetadata } from "common/seo";
+
+/**
+ * Exists so /downloads gets its own title and description -- page.tsx is a client component
+ * and cannot export `metadata` itself.
+ */
+export const metadata = pageMetadata({
+  title: "Download cCRE Data",
+  description:
+    "Download ENCODE candidate cis-regulatory element (cCRE) annotations, signal and z-score data matrices, and cCREs within a specific genomic region, for human (GRCh38) and mouse (mm10).",
+  path: "/downloads",
+});
+
+export default function DownloadsLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/downloads/page.tsx
+++ b/src/app/downloads/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { Tabs, Tab, Divider, Box } from "@mui/material";
+import { Tabs, Tab, Divider, Box, Typography } from "@mui/material";
 import { DataMatrices } from "./_DataMatrices/DataMatrices";
 import { useState } from "react";
 import { DownloadRange } from "./_DownloadRange/DownloadRange";
@@ -31,6 +31,28 @@ export default function Downloads() {
       gap={2}
       id="downloads"
     >
+      {/*
+        The page leads straight into the tabs, so there is no visible heading to promote. This
+        gives screen readers and crawlers the main heading the page otherwise lacks, without
+        changing the layout. Standard clip-rect pattern -- display:none would hide it from both.
+      */}
+      <Typography
+        variant="h1"
+        component="h1"
+        sx={{
+          position: "absolute",
+          width: 1,
+          height: 1,
+          padding: 0,
+          margin: -1,
+          overflow: "hidden",
+          clip: "rect(0 0 0 0)",
+          whiteSpace: "nowrap",
+          border: 0,
+        }}
+      >
+        Download cCRE Data
+      </Typography>
       <Box id="downloads-tabs" minWidth={0}>
         <Tabs
           value={page}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,3 +1,9 @@
+import type { Metadata } from "next";
+import { SITE_URL } from "./sitemap";
+import { SITE_NAME, TITLE_TEMPLATE } from "common/seo";
+
+const HOMEPAGE_DESCRIPTION =
+  "Explore candidate cis-regulatory elements (cCREs) from ENCODE. Search genes, cCREs, variants, GWAS studies, and genomic regions across human (GRCh38) and mouse (mm10).";
 import { CssBaseline } from "@mui/material";
 import { AppRouterCacheProvider } from "@mui/material-nextjs/v13-appRouter";
 import { Analytics } from "@vercel/analytics/next";
@@ -10,9 +16,40 @@ import { loadErrorMessages, loadDevMessages } from "@apollo/client/dev";
 import ClientAppWrapper from "common/components/ClientAppWrapper";
 import Theme from "common/components/Theme";
 
-export const metadata = {
-  title: "SCREEN: Search Candidate cis-Regulatory Elements by ENCODE",
-  description: "SCREEN: Search Candidate cis-Regulatory Elements by ENCODE",
+/**
+ * Site-wide metadata defaults, which double as the homepage's own metadata -- page.tsx is a
+ * client component and so cannot export `metadata` itself.
+ *
+ * Every other indexable page overrides `title` and `description` (via its own layout.tsx where
+ * that page is also a client component). Anything that doesn't inherits the values below, so
+ * keep them accurate for the homepage specifically rather than generic boilerplate.
+ *
+ * `template` applies to child pages that set a string title: "Downloads" renders as
+ * "Downloads | SCREEN". `default` is used as-is, with no template applied.
+ *
+ * Deliberately no `alternates.canonical` here: metadata is inherited, so a canonical set at the
+ * root would point every page that forgets to override it at the homepage and deindex it.
+ */
+export const metadata: Metadata = {
+  metadataBase: new URL(SITE_URL),
+  title: {
+    default: "SCREEN: Search Candidate cis-Regulatory Elements by ENCODE",
+    template: TITLE_TEMPLATE,
+  },
+  description: HOMEPAGE_DESCRIPTION,
+  openGraph: {
+    title: "SCREEN: Search Candidate cis-Regulatory Elements by ENCODE",
+    description: HOMEPAGE_DESCRIPTION,
+    url: "/",
+    siteName: SITE_NAME,
+    type: "website",
+    locale: "en_US",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "SCREEN: Search Candidate cis-Regulatory Elements by ENCODE",
+    description: HOMEPAGE_DESCRIPTION,
+  },
 };
 
 if (process.env.NODE_ENV !== "production") {

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,21 +1,32 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
 import { ImageResponse } from "next/og";
 
 /**
  * Social share card, generated at build time and served as a static PNG.
  *
- * Generated rather than checked in because the logos in public/ are transparent RGBA at a 1.95
- * aspect ratio; social platforms composite transparency onto their own background, so a
- * dark-ink logo disappears on dark-mode cards. This paints an opaque background at the 1200x630
- * both OpenGraph and Twitter expect.
+ * Generated rather than checked in so the real logo can be composited onto a background we
+ * control: public/on-dark@16x.png is transparent RGBA with white ink, and social platforms paint
+ * transparency onto their own card background, so the wordmark disappears wherever that
+ * background is light. Painting the brand gradient behind it here pins the logo to the dark
+ * background it was drawn for, at the 1200x630 both OpenGraph and Twitter expect.
  *
  * Rendered by satori, which supports only a subset of CSS: every element with more than one
- * child needs an explicit `display: flex`, and there is no cascade to inherit from.
+ * child needs an explicit `display: flex`, and there is no cascade to inherit from. It also has
+ * no filesystem or network access, so the logo is read here and handed over as a data URI.
  */
 export const alt = "SCREEN: Search Candidate cis-Regulatory Elements by ENCODE";
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
 
-export default function OpengraphImage() {
+/** Source asset is 1869x960 and tightly cropped; scaled down at its own aspect ratio. */
+const LOGO_WIDTH = 620;
+const LOGO_HEIGHT = Math.round((LOGO_WIDTH * 960) / 1869);
+
+export default async function OpengraphImage() {
+  const logo = await readFile(join(process.cwd(), "public", "on-dark@16x.png"));
+  const logoSrc = `data:image/png;base64,${logo.toString("base64")}`;
+
   return new ImageResponse(
     <div
       style={{
@@ -27,17 +38,12 @@ export default function OpengraphImage() {
         padding: "0 90px",
         // theme.palette.primary.main -> secondary.main
         backgroundImage: "linear-gradient(135deg, #0c184a 0%, #00063D 100%)",
-        color: "white",
         fontFamily: "sans-serif",
       }}
     >
-      <div style={{ fontSize: 128, fontWeight: 700, letterSpacing: -2 }}>SCREEN</div>
-      <div style={{ fontSize: 46, lineHeight: 1.25, marginTop: 12, color: "#e4ebff" }}>
+      <img src={logoSrc} width={LOGO_WIDTH} height={LOGO_HEIGHT} alt="" />
+      <div style={{ fontSize: 46, lineHeight: 1.25, marginTop: 28, color: "#e4ebff" }}>
         Search Candidate cis-Regulatory Elements
-      </div>
-      <div style={{ display: "flex", alignItems: "center", marginTop: 40 }}>
-        <div style={{ width: 72, height: 6, background: "#100e98", marginRight: 22 }} />
-        <div style={{ fontSize: 30, color: "#b2bcf0" }}>by ENCODE &middot; human &amp; mouse</div>
       </div>
     </div>,
     size

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,0 +1,45 @@
+import { ImageResponse } from "next/og";
+
+/**
+ * Social share card, generated at build time and served as a static PNG.
+ *
+ * Generated rather than checked in because the logos in public/ are transparent RGBA at a 1.95
+ * aspect ratio; social platforms composite transparency onto their own background, so a
+ * dark-ink logo disappears on dark-mode cards. This paints an opaque background at the 1200x630
+ * both OpenGraph and Twitter expect.
+ *
+ * Rendered by satori, which supports only a subset of CSS: every element with more than one
+ * child needs an explicit `display: flex`, and there is no cascade to inherit from.
+ */
+export const alt = "SCREEN: Search Candidate cis-Regulatory Elements by ENCODE";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default function OpengraphImage() {
+  return new ImageResponse(
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "center",
+        padding: "0 90px",
+        // theme.palette.primary.main -> secondary.main
+        backgroundImage: "linear-gradient(135deg, #0c184a 0%, #00063D 100%)",
+        color: "white",
+        fontFamily: "sans-serif",
+      }}
+    >
+      <div style={{ fontSize: 128, fontWeight: 700, letterSpacing: -2 }}>SCREEN</div>
+      <div style={{ fontSize: 46, lineHeight: 1.25, marginTop: 12, color: "#e4ebff" }}>
+        Search Candidate cis-Regulatory Elements
+      </div>
+      <div style={{ display: "flex", alignItems: "center", marginTop: 40 }}>
+        <div style={{ width: 72, height: 6, background: "#100e98", marginRight: 22 }} />
+        <div style={{ fontSize: 30, color: "#b2bcf0" }}>by ENCODE &middot; human &amp; mouse</div>
+      </div>
+    </div>,
+    size
+  );
+}

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -4,16 +4,6 @@ import { ImageResponse } from "next/og";
 
 /**
  * Social share card, generated at build time and served as a static PNG.
- *
- * Generated rather than checked in so the real logo can be composited onto a background we
- * control: public/on-dark@16x.png is transparent RGBA with white ink, and social platforms paint
- * transparency onto their own card background, so the wordmark disappears wherever that
- * background is light. Painting the brand gradient behind it here pins the logo to the dark
- * background it was drawn for, at the 1200x630 both OpenGraph and Twitter expect.
- *
- * Rendered by satori, which supports only a subset of CSS: every element with more than one
- * child needs an explicit `display: flex`, and there is no cascade to inherit from. It also has
- * no filesystem or network access, so the logo is read here and handed over as a data URI.
  */
 export const alt = "SCREEN: Search Candidate cis-Regulatory Elements by ENCODE";
 export const size = { width: 1200, height: 630 };

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -67,6 +67,8 @@ export default function Home() {
 
           <Typography
             variant="h4"
+            /* Renders as <h1> while keeping the h4 styling -- this is the page's main heading. */
+            component="h1"
             sx={{
               fontWeight: 400,
               fontSize: { xs: "28px", md: "40px" },

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -4,24 +4,6 @@ import { SITE_URL } from "./sitemap";
 /**
  * Crawler policy: deny by default, allowing only the static pages in the top nav
  * (see common/components/Header/navLinks.ts).
- *
- * Entity pages at /{assembly}/{entityType}/{entityID}/{tab} span an effectively unbounded
- * URL space -- /{assembly}/region/{chr}:{start}-{end} accepts any genomic coordinate, so
- * there is no finite set of URLs for a crawler to work through and a crawl never finishes.
- * Each request also costs an SSR render plus a fan-out of client-side /api/graphql calls,
- * so an unattended crawl runs up hosting usage indefinitely. Googlebot, Applebot and
- * AhrefsBot have all done exactly this.
- *
- * Keep this deny-by-default rather than listing routes to block: the dynamic routes sit at
- * the root (/GRCh38/..., /mm10/...) and share no prefix, so there is nothing to target. New
- * routes are therefore blocked unless added to `allow` below.
- *
- * Scope: this only stops well-behaved crawlers, and it cannot remove URLs already indexed
- * (a blocked page can't be re-crawled to see a noindex). Scrapers that ignore robots.txt
- * need to be handled at the edge instead.
- *
- * Comments here are stripped from the generated /robots.txt, which is public. Keep any
- * detail about internals in this file rather than in the emitted output.
  */
 export default function robots(): MetadataRoute.Robots {
   return {

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,55 @@
+import type { MetadataRoute } from "next";
+import { SITE_URL } from "./sitemap";
+
+/**
+ * Crawler policy: deny by default, allowing only the static pages in the top nav
+ * (see common/components/Header/navLinks.ts).
+ *
+ * Entity pages at /{assembly}/{entityType}/{entityID}/{tab} span an effectively unbounded
+ * URL space -- /{assembly}/region/{chr}:{start}-{end} accepts any genomic coordinate, so
+ * there is no finite set of URLs for a crawler to work through and a crawl never finishes.
+ * Each request also costs an SSR render plus a fan-out of client-side /api/graphql calls,
+ * so an unattended crawl runs up hosting usage indefinitely. Googlebot, Applebot and
+ * AhrefsBot have all done exactly this.
+ *
+ * Keep this deny-by-default rather than listing routes to block: the dynamic routes sit at
+ * the root (/GRCh38/..., /mm10/...) and share no prefix, so there is nothing to target. New
+ * routes are therefore blocked unless added to `allow` below.
+ *
+ * Scope: this only stops well-behaved crawlers, and it cannot remove URLs already indexed
+ * (a blocked page can't be re-crawled to see a noindex). Scrapers that ignore robots.txt
+ * need to be handled at the edge instead.
+ *
+ * Comments here are stripped from the generated /robots.txt, which is public. Keep any
+ * detail about internals in this file rather than in the emitted output.
+ */
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: [
+        // Homepage. The $ anchor is load-bearing -- a bare "/" would re-open the entire site.
+        "/$",
+        // Prefix matches, so /about also covers /about/versions.
+        "/about",
+        "/downloads",
+        // Assets required to render the pages allowed above. Without these Googlebot fetches
+        // the homepage, fails to load its images and stylesheets, and scores it as broken. The
+        // extension wildcards cover the root-level images in public/ (/helix.png, /treemap.svg,
+        // ...) and the /versionScreenshots images on /about/versions, without needing a list
+        // that drifts as assets are added.
+        "/_next/static/",
+        "/assets/",
+        "/*.svg$",
+        "/*.png$",
+        // Social share card from opengraph-image.tsx. Needs its own entry because the route is
+        // /opengraph-image?<hash> with no .png extension, so the wildcard above does not cover
+        // it. Slackbot, Twitterbot and friends honor robots.txt when fetching preview images --
+        // without this the cards render with no image.
+        "/opengraph-image",
+      ],
+      disallow: "/",
+    },
+    sitemap: `${SITE_URL}/sitemap.xml`,
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,12 +1,35 @@
 import type { MetadataRoute } from "next";
 import { RELEASE_NOTES } from "app/about/versions/releaseNotes";
 
+const PRODUCTION_URL = "https://screen.wenglab.org";
+
 /**
- * Canonical origin. Sitemap entries must be on the same host as the sitemap itself --
- * Google discards cross-host URLs -- so this needs to match where the app is actually
- * served, not a preview or legacy domain.
+ * Canonical origin for this deployment. Backs `metadataBase`, so it resolves every canonical
+ * link, OpenGraph image and sitemap entry.
+ *
+ * Sitemap entries must be on the same host as the sitemap serving them -- Google discards
+ * cross-host URLs -- so this has to track where the app is actually served.
+ *
+ * Production deliberately keeps the hardcoded domain rather than reading VERCEL_URL: on Vercel
+ * that variable is the generated deployment hostname (screen-<hash>-<team>.vercel.app), not the
+ * custom domain, even for production deploys. Using it there would point canonicals at a URL
+ * users never visit and split ranking signals across two hosts.
+ *
+ * Preview deployments use their own origin so share cards and canonicals resolve to the
+ * deployment being previewed instead of reaching into production -- which is what makes it
+ * possible to test an OpenGraph card before it ships. Vercel serves previews with
+ * X-Robots-Tag: noindex, so these origins never reach a search index.
+ *
+ * Everywhere else (local dev, CI) falls back to production, which keeps a local `yarn build`
+ * comparable with what production emits.
+ *
+ * Read at build time: robots.txt and sitemap.xml are statically generated, so each deployment
+ * bakes in its own origin.
  */
-export const SITE_URL = "https://screen.wenglab.org";
+export const SITE_URL =
+  process.env.VERCEL_ENV !== "production" && process.env.VERCEL_URL
+    ? `https://${process.env.VERCEL_URL}`
+    : PRODUCTION_URL;
 
 /**
  * Latest release date as YYYY-MM-DD, or undefined if it can't be read.

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,47 @@
+import type { MetadataRoute } from "next";
+import { RELEASE_NOTES } from "app/about/versions/releaseNotes";
+
+/**
+ * Canonical origin. Sitemap entries must be on the same host as the sitemap itself --
+ * Google discards cross-host URLs -- so this needs to match where the app is actually
+ * served, not a preview or legacy domain.
+ */
+export const SITE_URL = "https://screen.wenglab.org";
+
+/**
+ * Latest release date as YYYY-MM-DD, or undefined if it can't be read.
+ *
+ * Derived from RELEASE_NOTES rather than hardcoded so it stays truthful as releases are
+ * added. That matters: Google only honors lastmod when it is "consistently and verifiably
+ * accurate", and a stale or always-current value teaches it to ignore the field entirely.
+ * For the same reason, do not fall back to new Date() here -- that would stamp the page as
+ * modified on every deploy.
+ */
+function latestReleaseDate(): string | undefined {
+  const raw = RELEASE_NOTES[0]?.date;
+  if (!raw) return undefined;
+
+  const parsed = new Date(raw);
+  if (Number.isNaN(parsed.getTime())) return undefined;
+
+  // Built from local parts instead of toISOString(), which shifts the calendar date across
+  // the UTC boundary depending on the timezone the build runs in.
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${parsed.getFullYear()}-${pad(parsed.getMonth() + 1)}-${pad(parsed.getDate())}`;
+}
+
+/**
+ * The pages crawlers are allowed to index, mirroring the allowlist in robots.ts. Keep the
+ * two in sync: a sitemap entry that robots.ts blocks is a contradictory signal, and Search
+ * Console reports it as an error.
+ *
+ * `priority` and `changeFrequency` are deliberately omitted -- Google ignores both.
+ */
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    { url: SITE_URL },
+    { url: `${SITE_URL}/about` },
+    { url: `${SITE_URL}/downloads` },
+    { url: `${SITE_URL}/about/versions`, lastModified: latestReleaseDate() },
+  ];
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,5 +1,5 @@
 import type { MetadataRoute } from "next";
-import { RELEASE_NOTES } from "app/about/versions/releaseNotes";
+import { parseReleaseDay, RELEASE_NOTES } from "app/about/versions/releaseNotes";
 
 const PRODUCTION_URL = "https://screen.wenglab.org";
 
@@ -32,25 +32,15 @@ export const SITE_URL =
     : PRODUCTION_URL;
 
 /**
- * Latest release date as YYYY-MM-DD, or undefined if it can't be read.
+ * Latest release date as YYYY-MM-DD, or undefined when the newest entry carries no exact day
+ * (legacy year-only releases) or is malformed.
  *
- * Derived from RELEASE_NOTES rather than hardcoded so it stays truthful as releases are
- * added. That matters: Google only honors lastmod when it is "consistently and verifiably
- * accurate", and a stale or always-current value teaches it to ignore the field entirely.
- * For the same reason, do not fall back to new Date() here -- that would stamp the page as
- * modified on every deploy.
+ * Assumes RELEASE_NOTES is ordered newest-first, which is also the order the versions page
+ * renders it in.
  */
 function latestReleaseDate(): string | undefined {
-  const raw = RELEASE_NOTES[0]?.date;
-  if (!raw) return undefined;
-
-  const parsed = new Date(raw);
-  if (Number.isNaN(parsed.getTime())) return undefined;
-
-  // Built from local parts instead of toISOString(), which shifts the calendar date across
-  // the UTC boundary depending on the timezone the build runs in.
-  const pad = (n: number) => String(n).padStart(2, "0");
-  return `${parsed.getFullYear()}-${pad(parsed.getMonth() + 1)}-${pad(parsed.getDate())}`;
+  const date = RELEASE_NOTES[0]?.date;
+  return date && parseReleaseDay(date) ? date : undefined;
 }
 
 /**

--- a/src/common/components/Footer.tsx
+++ b/src/common/components/Footer.tsx
@@ -21,8 +21,6 @@ const sections = [
       { name: "PsychSCREEN", href: "https://psychscreen.wenglab.org/psychscreen" },
       { name: "igSCREEN", href: "https://igscreen.vercel.app/" },
       { name: "Factorbook", href: "https://www.factorbook.org/" },
-      // { name: "GWAS", href: "/gwas" },
-      // { name: "ARGO", href: "/argo" },
     ],
   },
   {

--- a/src/common/components/Header/Header.tsx
+++ b/src/common/components/Header/Header.tsx
@@ -15,7 +15,7 @@ import NewVersionBanner from "./NewVersionBanner";
 import DesktopNav from "./DesktopNav";
 import AssemblySelect from "./AssemblySelect";
 import HeaderSearch from "./HeaderSearch";
-import { pageLinks } from "./navLinks";
+import { HEADER_NAV_LINKS } from "./navLinks";
 
 type ResponsiveAppBarProps = {
   maintenance?: boolean;
@@ -46,7 +46,7 @@ function Header({ maintenance }: ResponsiveAppBarProps) {
               style={{ objectFit: "contain", objectPosition: "left center" }}
             />
           </Box>
-          <DesktopNav pageLinks={pageLinks} />
+          <DesktopNav pageLinks={HEADER_NAV_LINKS} />
         </Stack>
         {isHomePage ? (
           <IconButton sx={{ color: "white", display: { xs: "none", md: "flex" } }} onClick={handleFocusSearch}>
@@ -64,7 +64,7 @@ function Header({ maintenance }: ResponsiveAppBarProps) {
             <MenuIcon />
           </IconButton>
         </Box>
-        <MobileMenu pageLinks={pageLinks} assembly={assembly} onAssemblyChange={setAssembly} />
+        <MobileMenu pageLinks={HEADER_NAV_LINKS} assembly={assembly} onAssemblyChange={setAssembly} />
       </Toolbar>
       {isHomePage && process.env.NEXT_PUBLIC_SHOW_RELEASE_BANNER === "true" && <NewVersionBanner />}
     </AppBar>

--- a/src/common/components/Header/navLinks.ts
+++ b/src/common/components/Header/navLinks.ts
@@ -1,7 +1,7 @@
 import { PageInfo } from "./types";
 
 /** Top level navigation, shared by the desktop nav and the mobile drawer */
-export const pageLinks: PageInfo[] = [
+export const HEADER_NAV_LINKS: PageInfo[] = [
   {
     pageName: "Downloads",
     link: "/downloads",
@@ -13,6 +13,7 @@ export const pageLinks: PageInfo[] = [
       { pageName: "Overview", link: "/about" },
       { pageName: "cCRE Classification", link: "/about#classifications" },
       { pageName: "How to Cite", link: "/about#citations" },
+      { pageName: "API Documentation", link: "/about#api-documentation" },
       { pageName: "Contact Us", link: "/about#contact-us" },
       { pageName: "Release History", link: "/about/versions" },
     ],

--- a/src/common/seo.ts
+++ b/src/common/seo.ts
@@ -1,0 +1,59 @@
+import type { Metadata } from "next";
+
+/** Suffix applied to child page titles, e.g. "Downloads" -> "Downloads | SCREEN". */
+export const TITLE_TEMPLATE = "%s | SCREEN";
+
+export const SITE_NAME = "SCREEN";
+
+/**
+ * The generated share card (app/opengraph-image.tsx).
+ *
+ * Referenced explicitly because a segment that declares its own `openGraph` replaces the
+ * parent's wholesale, including the image the file convention injects at the root. Without
+ * this every page except the homepage ships an image-less card.
+ */
+const OG_IMAGE = "/opengraph-image";
+
+/**
+ * Builds a page's metadata block.
+ *
+ * Exists so `title` and `description` reach <title>, <meta name="description">, OpenGraph and
+ * Twitter from a single source. Written out by hand these drift -- someone updates the meta
+ * description and leaves og:description describing the old page.
+ *
+ * `title` is passed bare (no "| SCREEN"): the parent template adds the suffix to the page title,
+ * while og:title intentionally stays unbranded because `og:site_name` already carries it.
+ *
+ * `template` is always set so any child segment keeps the suffix. It is a no-op for pages that
+ * have no children, and omitting it is the bug that silently strips branding one level down.
+ */
+export function pageMetadata({
+  title,
+  description,
+  path,
+}: {
+  title: string;
+  description: string;
+  /** Root-relative, e.g. "/downloads". Resolved against `metadataBase`. */
+  path: string;
+}): Metadata {
+  return {
+    title: { default: title, template: TITLE_TEMPLATE },
+    description,
+    alternates: { canonical: path },
+    openGraph: {
+      title,
+      description,
+      url: path,
+      siteName: SITE_NAME,
+      type: "website",
+      images: [OG_IMAGE],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      images: [OG_IMAGE],
+    },
+  };
+}


### PR DESCRIPTION
- Adds robots.txt and sitemap.ts
- Adds Opengraph image (the image that pops up when you paste a link into programs like Slack)
- Ensures proper h1 headings on indexable pages
- Adds unique metadata for indexable pages to tell crawlers what the page is more clearly
- Strictly types the date in RELEASE_NOTES since now the sitemap relies upon that for the last modified date

Of note:
- Removed the blanket block on bots and rule against google specifically on Vercel. Will monitor usage periodically to catch any more runaway indexing situations. Especially until this gets into main